### PR TITLE
Add orientation toggle for web app

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -16,12 +16,17 @@ import 'dart:html' as html;
 import 'package:responsive_framework/responsive_framework.dart';
 import 'package:digimon_meta_site_flutter/service/card_data_service.dart';
 import 'package:digimon_meta_site_flutter/provider/note_provider.dart';
+import 'package:digimon_meta_site_flutter/service/orientation_service.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
   setPathUrlStrategy();
   final appRouter = AppRouter();
   WidgetsFlutterBinding.ensureInitialized();
+
+  // 화면 자동 회전 설정 적용
+  await OrientationService.applyAutoRotate(
+      OrientationService.loadAutoRotate());
 
   // 앱 시작 전 카드 데이터 초기화
   await CardDataService().initialize();

--- a/lib/service/deck_service.dart
+++ b/lib/service/deck_service.dart
@@ -31,6 +31,7 @@ import '../provider/deck_sort_provider.dart';
 import '../provider/limit_provider.dart';
 import '../provider/user_provider.dart';
 import '../service/user_setting_service.dart';
+import 'orientation_service.dart';
 import 'package:image/image.dart' as imglib;
 
 import '../router.dart';
@@ -999,6 +1000,7 @@ class DeckService {
             }
             
             bool isStrict = deck.isStrict;
+            bool autoRotate = OrientationService.loadAutoRotate();
             List<SortCriterion> sortPriority = List.from(
               deckSortProvider.sortPriority.map(
                 (criterion) => SortCriterion(
@@ -1270,6 +1272,33 @@ class DeckService {
                           ),
                         ],
                       ),
+                      if (OrientationService.isWebApp()) ...[
+                        Divider(),
+                        Row(
+                          mainAxisAlignment: MainAxisAlignment.spaceAround,
+                          children: [
+                            Text(
+                              '화면 자동 회전',
+                              style: TextStyle(
+                                  fontSize: SizeService.bodyFontSize(context)),
+                            ),
+                            Transform.scale(
+                              scale: SizeService.switchScale(context),
+                              child: Switch(
+                                inactiveThumbColor: Colors.red,
+                                value: autoRotate,
+                                onChanged: (bool v) {
+                                  setState(() {
+                                    autoRotate = v;
+                                  });
+                                  OrientationService.saveAutoRotate(v);
+                                  OrientationService.applyAutoRotate(v);
+                                },
+                              ),
+                            ),
+                          ],
+                        ),
+                      ],
                       Divider(),
                       Row(
                         mainAxisAlignment: MainAxisAlignment.center,

--- a/lib/service/orientation_service.dart
+++ b/lib/service/orientation_service.dart
@@ -1,0 +1,35 @@
+import 'dart:html' as html;
+import 'package:flutter/foundation.dart';
+
+class OrientationService {
+  static const String _autoRotateKey = 'allowAutoRotate';
+
+  static bool loadAutoRotate() {
+    final stored = html.window.localStorage[_autoRotateKey];
+    if (stored == null) return true;
+    return stored.toLowerCase() != 'false';
+  }
+
+  static void saveAutoRotate(bool value) {
+    html.window.localStorage[_autoRotateKey] = value.toString();
+  }
+
+  static Future<void> applyAutoRotate(bool value) async {
+    try {
+      if (value) {
+        await html.window.screen?.orientation?.unlock();
+      } else {
+        await html.window.screen?.orientation?.lock('portrait');
+      }
+    } catch (_) {}
+  }
+
+  static bool isWebApp() {
+    if (!kIsWeb) return false;
+    try {
+      return html.window.matchMedia('(display-mode: standalone)').matches;
+    } catch (_) {
+      return false;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add OrientationService to manage auto rotate setting on web
- apply orientation setting at startup
- expose a toggle in deck settings when running as a web app

## Testing
- `dart format lib/service/orientation_service.dart lib/main.dart lib/service/deck_service.dart` *(fails: `dart: command not found`)*